### PR TITLE
Fix typo in the comments in user-list.component.ts

### DIFF
--- a/client/src/app/users/user-list.component.ts
+++ b/client/src/app/users/user-list.component.ts
@@ -21,11 +21,11 @@ export class UserListComponent implements OnInit {
   public viewType: 'card' | 'list' = 'card';
 
 
-  // Inject the Usecontainsrvice into this component.
-  // That's what hacontainsns in the following constructor.
+  // Inject the UserService into this component.
+  // That's what happens in the following constructor.
   //
-  // We can call upcontainsthe service for interacting
-  // with the servecontains
+  // We can call upon the service for interacting
+  // with the server
 
   constructor(private userService: UserService) {
 


### PR DESCRIPTION
We had accidentally pasted some text into one of the comments in user-list.component.ts, creating some gibberish. This commit changes the comments back to what they originally said.