### PR TITLE
Make TodoService ignore falsy parameters

### DIFF
--- a/client/src/app/todos/todo.service.spec.ts
+++ b/client/src/app/todos/todo.service.spec.ts
@@ -109,6 +109,23 @@ describe('Todo service: ', () => {
 
       req.flush(testTodos);
     });
+
+    it('ignores parameters whose value is undefined', () => {
+      todoService.getTodos({ category: 'chores', status: undefined, owner: undefined }).subscribe(
+        todos => expect(todos).toBe(testTodos)
+      );
+      const req = httpTestingController.expectOne(
+        request => request.url.startsWith(todoService.todoUrl)
+          && request.params.has('category')
+          && !request.params.has('owner')
+          && !request.params.has('status')
+      );
+
+      expect(req.request.method).toEqual('GET');
+      expect(req.request.params.get('category')).toEqual('chores');
+
+      req.flush(testTodos);
+    });
   });
 
   describe('filterTodos: ', () => {

--- a/client/src/app/todos/todo.service.spec.ts
+++ b/client/src/app/todos/todo.service.spec.ts
@@ -99,7 +99,7 @@ describe('Todo service: ', () => {
       );
       const req = httpTestingController.expectOne(
         request => request.url.startsWith(todoService.todoUrl) && request.params.has('category') &&
-          request.params.has('owner') && request.params.has('category')
+          request.params.has('owner') && request.params.has('status')
       );
 
       expect(req.request.method).toEqual('GET');

--- a/client/src/app/todos/todo.service.spec.ts
+++ b/client/src/app/todos/todo.service.spec.ts
@@ -177,5 +177,11 @@ describe('Todo service: ', () => {
       const filteredTodos = todoService.filterTodos(testTodos, { body: 'Mr. Scruffles', category: 'Chores' });
       expect(filteredTodos.length).toBe(1);
     });
+
+    it('ignores parameters whose values are undefined', () => {
+      expect(testTodos.length).toBe(4);
+      const filteredTodos = todoService.filterTodos(testTodos, { body: undefined, category: 'Chores' });
+      expect(filteredTodos.length).toBe(3);
+    });
   });
 });

--- a/client/src/app/todos/todo.service.spec.ts
+++ b/client/src/app/todos/todo.service.spec.ts
@@ -126,6 +126,23 @@ describe('Todo service: ', () => {
 
       req.flush(testTodos);
     });
+
+    it('ignores parameters whose values are falsy', () => {
+      todoService.getTodos({ category: 'chores', status: '', owner: null }).subscribe(
+        todos => expect(todos).toBe(testTodos)
+      );
+      const req = httpTestingController.expectOne(
+        request => request.url.startsWith(todoService.todoUrl)
+          && request.params.has('category')
+          && !request.params.has('owner')
+          && !request.params.has('status')
+      );
+
+      expect(req.request.method).toEqual('GET');
+      expect(req.request.params.get('category')).toEqual('chores');
+
+      req.flush(testTodos);
+    });
   });
 
   describe('filterTodos: ', () => {
@@ -181,6 +198,12 @@ describe('Todo service: ', () => {
     it('ignores parameters whose values are undefined', () => {
       expect(testTodos.length).toBe(4);
       const filteredTodos = todoService.filterTodos(testTodos, { body: undefined, category: 'Chores' });
+      expect(filteredTodos.length).toBe(3);
+    });
+
+    it('ignores parameters whose values are falsy', () => {
+      expect(testTodos.length).toBe(4);
+      const filteredTodos = todoService.filterTodos(testTodos, { body: null, owner: '', category: 'Chores' });
       expect(filteredTodos.length).toBe(3);
     });
   });

--- a/client/src/app/todos/todo.service.spec.ts
+++ b/client/src/app/todos/todo.service.spec.ts
@@ -110,7 +110,7 @@ describe('Todo service: ', () => {
       req.flush(testTodos);
     });
 
-    it('ignores parameters whose value is undefined', () => {
+    it('ignores parameters whose values are undefined', () => {
       todoService.getTodos({ category: 'chores', status: undefined, owner: undefined }).subscribe(
         todos => expect(todos).toBe(testTodos)
       );

--- a/client/src/app/todos/todo.service.ts
+++ b/client/src/app/todos/todo.service.ts
@@ -19,7 +19,9 @@ export class TodoService {
       owner?: string }): Observable<Todo[]> {
     let httpParams: HttpParams = new HttpParams();
     for (const fieldName in filters) {
-      if (filters.hasOwnProperty(fieldName)) {
+      // When the front-end passes us filters with falsy values
+      // (like empty-string) it expects us to ignore them.
+      if (filters.hasOwnProperty(fieldName) && filters[fieldName]) {
         httpParams = httpParams.set(fieldName, filters[fieldName]);
       }
     }
@@ -34,7 +36,9 @@ export class TodoService {
       category?: string }): Todo[] {
     let filteredTodos = todos.slice();
     for (const fieldName in filters) {
-      if (filters.hasOwnProperty(fieldName)) {
+      // When the front-end passes us filters with falsy values
+      // (like empty-string) it expects us to ignore them.
+      if (filters.hasOwnProperty(fieldName) && filters[fieldName]) {
         filteredTodos = filteredTodos.filter(todo =>
           todo[fieldName].toLowerCase().indexOf(filters[fieldName].toLowerCase()) !== -1);
       }


### PR DESCRIPTION
When the front-end passes TodoService filters with falsy values (like empty-string) it expects TodoService to ignore them. Previously, TodoService was not ignoring them, and was sending them to the server, which was complaining.
